### PR TITLE
Fix broken --font-editor-override default value

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -41,7 +41,7 @@ export const DEFAULT_SETTINGS: MinimalSettings = {
   darkStyle: 'minimal-dark',
   lightScheme: 'minimal-default-light',
   darkScheme: 'minimal-default-dark',
-  editorFont: '',
+  editorFont: "'??'",
   lineHeight: 1.5,
   lineWidth: 40,
   lineWidthWide: 50,
@@ -517,8 +517,8 @@ export class MinimalSettingsTab extends PluginSettingTab {
         }));
     new Setting(containerEl)
       .setName('Editor font')
-      .setDesc('Overrides the text font defined in Obsidian Appearance settings when in edit mode.')
-      .addText(text => text.setPlaceholder('')
+      .setDesc('Overrides the text font defined in Obsidian Appearance settings when in edit mode (default "??").')
+      .addText(text => text.setPlaceholder("'??'")
         .setValue((this.plugin.settings.editorFont || '') + '')
         .onChange((value) => {
           this.plugin.settings.editorFont = value;


### PR DESCRIPTION
The default value (empty string) for `--font-editor-override` interferes with the way the base Minimal plugin defines the `--font-editor` variable (https://github.com/kepano/obsidian-minimal/blob/8cb709a373c9601a9e9172eaa75fdbeba4412c43/src/scss/variables/root.scss#L3) causing it to hold an invalid value (e.g. see embedded image), and interferes with themeing specified otherwise.

![image](https://github.com/user-attachments/assets/e1790763-e8d9-4329-9389-63be96ec8c6d)

This PR 1) fixes it to use the strategy in base Obsidian to use a dummy `'??'` font (notice it being set on `--font-text-override` from the core Appearance settings by default), and 2) changes the settings item to be more in line with how other settings are presented as well.

Note of course that there is a lack of validation in these values and that changing most other settings here to empty or invalid values breaks stuff, but this seems to be the only one with a problematic default value and adding in validation is out of scope for this tiny PR.