### PR TITLE
Added dim inactive editor setting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -155,6 +155,16 @@ export default class MinimalTheme extends Plugin {
     });
 
     this.addCommand({
+      id: 'toggle-dim-inactive-editor',
+      name: 'Toggle dim inactive editor',
+      callback: () => {
+        this.settings.dimInactiveEditor = !this.settings.dimInactiveEditor;
+        this.saveData(this.settings);
+        this.refresh();
+      }
+    });
+
+    this.addCommand({
       id: 'toggle-minimal-focus-mode',
       name: 'Toggle focus mode',
       callback: () => {
@@ -730,6 +740,7 @@ export default class MinimalTheme extends Plugin {
     document.body.classList.toggle('full-file-names', !this.settings.trimNames);
     document.body.classList.toggle('labeled-nav', this.settings.labeledNav);
     document.body.classList.toggle('minimal-folding', this.settings.folding);
+    document.body.classList.toggle('dim-inactive-editor', this.settings.dimInactiveEditor);
 
     document.body.addClass(
       this.settings.chartWidth,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -34,6 +34,7 @@ export interface MinimalSettings {
   folding: boolean;
   lineNumbers: boolean;
   readableLineLength: boolean;
+  dimInactiveEditor: boolean;
 }
 
 export const DEFAULT_SETTINGS: MinimalSettings = {
@@ -69,6 +70,7 @@ export const DEFAULT_SETTINGS: MinimalSettings = {
   lineNumbers: false,
   readableLineLength: false,
   devBlockWidth: false,
+  dimInactiveEditor: false,
 }
 
 export class MinimalSettingsTab extends PluginSettingTab {
@@ -287,6 +289,16 @@ export class MinimalSettingsTab extends PluginSettingTab {
         .addToggle(toggle => toggle.setValue(this.plugin.settings.bordersToggle)
           .onChange((value) => {
             this.plugin.settings.bordersToggle = value;
+            this.plugin.saveData(this.plugin.settings);
+            this.plugin.refresh();
+          }));
+
+      new Setting(containerEl)
+        .setName('Dim inactive editor')
+        .setDesc('Dim inactive editor when split into multiple panes.')
+        .addToggle(toggle => toggle.setValue(this.plugin.settings.dimInactiveEditor)
+          .onChange((value) => {
+            this.plugin.settings.dimInactiveEditor = value;
             this.plugin.saveData(this.plugin.settings);
             this.plugin.refresh();
           }));


### PR DESCRIPTION
Added an option to toggle dim inactive editor. Useful when using live preview/source with split views. Related CSS PR: https://github.com/kepano/obsidian-minimal/pull/851